### PR TITLE
Changed library name depending on OS

### DIFF
--- a/src/Mercury.jl
+++ b/src/Mercury.jl
@@ -4,7 +4,14 @@ import Sockets
 import ProtoBuf
 import Logging
 
-const libhg = joinpath(@__DIR__, "..", "deps", "build", "libhg.so")
+# Import correct library name for specific system
+libhg_library_filename = ""
+if Sys.islinux()
+    libhg_library_filename = joinpath(@__DIR__, "..", "deps", "build", "libhg.so")
+elseif Sys.isapple()
+    libhg_library_filename = joinpath(@__DIR__, "..", "deps", "build", "libhg.dylib")
+end
+const libhg = libhg_library_filename
 
 
 greet() = print("Hello World!")


### PR DESCRIPTION
I just added a if/elseif statement in `Mercury.jl` which changes the name of the C library containing the usleep function from `libhg.so` -> `libhg.dylib`.