### PR TITLE
Add node options

### DIFF
--- a/src/Mercury.jl
+++ b/src/Mercury.jl
@@ -17,7 +17,6 @@ end
 const libhg = libhg_library_filename
 
 
-greet() = print("Hello World!")
 include("utils.jl")
 include("rate_limiter.jl")
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -4,7 +4,7 @@ Base.@kwdef mutable struct NodeOptions
 end
 
 Base.@kwdef mutable struct NodeFlags
-    did_error::Threads.Atomic{Bool} = Threads.Atomic{Bool}(false) 
+    did_error::Threads.Atomic{Bool} = Threads.Atomic{Bool}(false)
     is_running::Threads.Atomic{Bool} = Threads.Atomic{Bool}(false)
     should_finish::Threads.Atomic{Bool} = Threads.Atomic{Bool}(false)
 end
@@ -27,7 +27,7 @@ struct NodeIO
     opts::NodeOptions
     flags::NodeFlags
 
-    function NodeIO(ctx::ZMQ.Context=ZMQ.context(); opts...)
+    function NodeIO(ctx::ZMQ.Context = ZMQ.context(); opts...)
         new(ctx, PublishedMessage[], SubscribedMessage[], NodeOptions(opts...), NodeFlags())
     end
 end
@@ -183,15 +183,15 @@ end
 ##############################
 getoptions(node::Node) = getIO(node).opts
 getflags(node::Node) = getIO(node).flags
-getrate(node::Node)::Float64 = getoptions(node).rate 
+getrate(node::Node)::Float64 = getoptions(node).rate
 function isnodedone(node::Node)::Bool
     nodeio = getIO(node)
     all_running = all(isrunning.(nodeio.subs))
     return getflags(node).should_finish[] || !all_running
 end
-function stopnode(node::Node; timeout=1.0)
+function stopnode(node::Node; timeout = 1.0)
     getflags(node).should_finish[] = true
-    t_start = time() 
+    t_start = time()
     while (time() - t_start < timeout)
         yield()
         if !(getflags(node).is_running[])
@@ -208,7 +208,8 @@ publishers(node::Node) = getIO(node).pubs
 subscribers(node::Node) = getIO(node).subs
 
 for pubsub in ((:publisher, :pubs), (:subscriber, :subs))
-    @eval $(Symbol("get", pubsub[1]))(node::Node, index::Integer) = getIO(node).$(pubsub[2])[index]
+    @eval $(Symbol("get", pubsub[1]))(node::Node, index::Integer) =
+        getIO(node).$(pubsub[2])[index]
     @eval function $(Symbol("get", pubsub[1]))(node::Node, name::String)
         index = findfirst(getIO(node).$(pubsub[2])) do msg
             getname(msg) == name
@@ -301,7 +302,7 @@ function launch(node::Node)
         end
         closeall(node)
     end
-    getflags(node).is_running[] = false 
+    getflags(node).is_running[] = false
 end
 
 function start_subscribers(node::Node)
@@ -339,6 +340,7 @@ function node_sockets_are_open(node::Node)
     )
 end
 
+#! format: off
 function printstatus(node::Node)
     is_running = getflags(node).is_running[]
     printstyled("Node name: ", bold=true); println(getname(node))
@@ -359,3 +361,4 @@ function printstatus(node::Node)
         end
     end
 end
+#! format: on

--- a/src/publishers/abstract_publisher.jl
+++ b/src/publishers/abstract_publisher.jl
@@ -26,5 +26,14 @@ struct PublishedMessage
         new(msg, pub, name)
     end
 end
-publish(pubmsg::PublishedMessage) = publish(pubmsg.pub, pubmsg.msg)
-getname(pubmsg::PublishedMessage) = pubmsg.name
+@inline publish(pubmsg::PublishedMessage) = publish(pubmsg.pub, pubmsg.msg)
+@inline getname(pubmsg::PublishedMessage) = pubmsg.name
+@inline getcomtype(pub::PublishedMessage) = getcomtype(pub.pub)
+
+function printstatus(pub::PublishedMessage; indent=0)
+    prefix = " " ^ indent
+    println(prefix, "Publisher: ", getname(pub))
+    println(prefix, "  Type: ", getcomtype(pub))
+    println(prefix, "  Message Type: ", typeof(pub.msg))
+    println(prefix, "  Has published? ", pub.pub.has_published[])
+end

--- a/src/publishers/abstract_publisher.jl
+++ b/src/publishers/abstract_publisher.jl
@@ -1,3 +1,7 @@
+Base.@kwdef mutable struct PublisherFlags
+    has_published::Threads.Atomic{Bool} = Threads.Atomic{Bool}(false)
+end
+
 abstract type Publisher end
 
 Base.isopen(sub::Publisher)::Nothing =
@@ -5,6 +9,7 @@ Base.isopen(sub::Publisher)::Nothing =
 Base.close(sub::Publisher)::Nothing =
     error("The `close` method hasn't been implemented for your Publisher yet!")
 getname(pub::Publisher)::String = pub.name
+getflags(pub::Publisher)::PublisherFlags = pub.flags
 
 function publish(pub::Publisher, proto_msg::ProtoBuf.ProtoType)::Nothing
     throw(
@@ -30,10 +35,12 @@ end
 @inline getname(pubmsg::PublishedMessage) = pubmsg.name
 @inline getcomtype(pub::PublishedMessage) = getcomtype(pub.pub)
 
+# TODO: add a `close` method and modify the constructor to automatically create a subscriber
+
 function printstatus(pub::PublishedMessage; indent=0)
     prefix = " " ^ indent
     println(prefix, "Publisher: ", getname(pub))
     println(prefix, "  Type: ", getcomtype(pub))
     println(prefix, "  Message Type: ", typeof(pub.msg))
-    println(prefix, "  Has published? ", pub.pub.has_published[])
+    println(prefix, "  Has published? ", getflags(pub.pub).has_published[])
 end

--- a/src/publishers/abstract_publisher.jl
+++ b/src/publishers/abstract_publisher.jl
@@ -37,8 +37,8 @@ end
 
 # TODO: add a `close` method and modify the constructor to automatically create a subscriber
 
-function printstatus(pub::PublishedMessage; indent=0)
-    prefix = " " ^ indent
+function printstatus(pub::PublishedMessage; indent = 0)
+    prefix = " "^indent
     println(prefix, "Publisher: ", getname(pub))
     println(prefix, "  Type: ", getcomtype(pub))
     println(prefix, "  Message Type: ", typeof(pub.msg))

--- a/src/publishers/zmq_publisher.jl
+++ b/src/publishers/zmq_publisher.jl
@@ -30,7 +30,7 @@ struct ZmqPublisher <: Publisher
     buffer::IOBuffer
     name::String
     ctx::ZMQ.Context
-    has_published::Threads.Atomic{Bool}
+    flags::PublisherFlags
 
     function ZmqPublisher(
         ctx::ZMQ.Context,
@@ -48,8 +48,7 @@ struct ZmqPublisher <: Publisher
             "Could not bind publisher $name to $(tcpstring(ipaddr, port))"
         )
         @info "Publishing $name on: $(tcpstring(ipaddr, port)), isopen = $(isopen(socket))"
-        has_published = Threads.Atomic{Bool}(false)
-        new(socket, port, ipaddr, IOBuffer(), name, ctx, has_published)
+        new(socket, port, ipaddr, IOBuffer(), name, ctx, PublisherFlags())
     end
 end
 function ZmqPublisher(ctx::ZMQ.Context, ipaddr, port::Integer; name = genpublishername())
@@ -84,7 +83,7 @@ function publish(pub::ZmqPublisher, proto_msg::ProtoBuf.ProtoType)
         # NOTE: ZMQ will de-allocate the message allocated above, so garbage
         # collection should not be an issue here
         ZMQ.send(pub.socket, msg)
-        pub.has_published[] = true
+        getflags(pub).has_published[] = true
 
         # Move to the beginning of the buffer
         seek(pub.buffer, 0)

--- a/src/subscribers/abstract_subscriber.jl
+++ b/src/subscribers/abstract_subscriber.jl
@@ -78,10 +78,12 @@ struct SubscribedMessage
         new(msg, sub, ReentrantLock(), name, Task[])
     end
 end
-@inline subscribe(submsg::SubscribedMessage) = subscribe(submsg.sub, submsg.msg, submsg.lock)
+@inline subscribe(submsg::SubscribedMessage) =
+    subscribe(submsg.sub, submsg.msg, submsg.lock)
 @inline getname(submsg::SubscribedMessage) = submsg.name
 @inline getcomtype(submsg::SubscribedMessage) = getcomtype(submsg.sub)
-isrunning(submsg::SubscribedMessage) = !isempty(submsg.task) && !istaskdone(submsg.task[end])
+isrunning(submsg::SubscribedMessage) =
+    !isempty(submsg.task) && !istaskdone(submsg.task[end])
 
 # TODO: add a `close` method and modify the constructor to automatically create a subscriber
 
@@ -96,8 +98,8 @@ function stopsubscriber(submsg::SubscribedMessage)
     wait(submsg.task[end])
 end
 
-function printstatus(sub::SubscribedMessage; indent=0)
-    prefix = " " ^ indent
+function printstatus(sub::SubscribedMessage; indent = 0)
+    prefix = " "^indent
     println(prefix, "Subscriber: ", getname(sub))
     println(prefix, "  Type: ", getcomtype(sub))
     println(prefix, "  Message Type: ", typeof(sub.msg))

--- a/src/subscribers/abstract_subscriber.jl
+++ b/src/subscribers/abstract_subscriber.jl
@@ -65,17 +65,35 @@ struct SubscribedMessage
     sub::Subscriber          # Note this is an abstract type
     lock::ReentrantLock
     name::String
+    task::Vector{Task}
 
     function SubscribedMessage(
         msg::ProtoBuf.ProtoType,
         sub::Subscriber;
         name = getname(sub),
     )
-        new(msg, sub, ReentrantLock(), name)
+        new(msg, sub, ReentrantLock(), name, Task[])
     end
 end
-subscribe(submsg::SubscribedMessage) = subscribe(submsg.sub, submsg.msg, submsg.lock)
-getname(submsg::SubscribedMessage) = submsg.name
+@inline subscribe(submsg::SubscribedMessage) = subscribe(submsg.sub, submsg.msg, submsg.lock)
+@inline getname(submsg::SubscribedMessage) = submsg.name
+@inline getcomtype(submsg::SubscribedMessage) = getcomtype(submsg.sub)
+isrunning(submsg::SubscribedMessage) = !isempty(submsg.task) && !istaskdone(submsg.task[end])
+
+function launchtask(submsg::SubscribedMessage)
+    push!(submsg.task, @async subscribe(submsg))
+    return submsg.task[end]
+end
+
+function printstatus(sub::SubscribedMessage; indent=0)
+    prefix = " " ^ indent
+    println(prefix, "Subscriber: ", getname(sub))
+    println(prefix, "  Type: ", getcomtype(sub))
+    println(prefix, "  Message Type: ", typeof(sub.msg))
+    println(prefix, "  Is running? ", !isempty(sub.task) && !istaskdone(sub.task[end]))
+    println(prefix, "  Is failed? ", !isempty(sub.task) && istaskfailed(sub.task[end]))
+    println(prefix, "  Has received? ", getflags(sub.sub).hasreceived)
+end
 
 """
     on_new(func::Function, submsg::SubscribedMessage)

--- a/src/subscribers/serial_subscriber.jl
+++ b/src/subscribers/serial_subscriber.jl
@@ -59,6 +59,7 @@ function SerialSubscriber(port_name::String, baudrate::Int64; name = gensubscrib
     return SerialSubscriber(sp; name = name)
 end
 
+getcomtype(::SerialSubscriber) = :serial
 
 Base.isopen(sub::SerialSubscriber) = LibSerialPort.isopen(sub.serial_port)
 function Base.close(sub::SerialSubscriber)

--- a/src/subscribers/zmq_subscriber.jl
+++ b/src/subscribers/zmq_subscriber.jl
@@ -65,7 +65,6 @@ struct ZmqSubscriber <: Subscriber
         )
 
         @info "Subscribing $name to: tcp://$ipaddr:$port"
-        @show isopen(socket)
         should_finish = Threads.Atomic{Bool}(false)
         new(
             socket,
@@ -96,10 +95,7 @@ function ZmqSubscriber(
     ZmqSubscriber(ctx, ipaddr, parse(Int, port), name = name)
 end
 
-function Subscriber(sub::ZmqSubscriber)
-    return sub
-end
-
+getcomtype(::ZmqSubscriber) = :zmq
 Base.isopen(sub::ZmqSubscriber) = isopen(sub.socket)
 
 function Base.close(sub::ZmqSubscriber, timeout = 1)
@@ -161,7 +157,6 @@ function subscribe(sub::ZmqSubscriber, buf, write_lock::ReentrantLock)
     catch err
         sub.flags.diderror = true
         close(sub)
-        @show typeof(err)
         if !(err isa EOFError)  # catch the EOFError throw when force closing the socket
             @warn "Shutting Down subscriber $(getname(sub)) on: $(tcpstring(sub)). Socket errored out."
             rethrow(err)

--- a/src/subscribers/zmq_subscriber.jl
+++ b/src/subscribers/zmq_subscriber.jl
@@ -64,15 +64,7 @@ struct ZmqSubscriber <: Subscriber
         )
 
         @info "Subscribing $name to: tcp://$ipaddr:$port"
-        new(
-            socket,
-            port,
-            ipaddr,
-            IOBuffer(),
-            name,
-            ReentrantLock(),
-            SubscriberFlags(),
-        )
+        new(socket, port, ipaddr, IOBuffer(), name, ReentrantLock(), SubscriberFlags())
     end
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 LibSerialPort = "a05a14c7-6e3b-5ba9-90a2-45558833e1df"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/test/node_tests.jl
+++ b/test/node_tests.jl
@@ -79,17 +79,35 @@ function Hg.compute(node::SubNode)
     println("Received x = $x")
 end
 
+
+println("######## NODE TESTS #############")
 ## Initialize publisher
 ctx = ZMQ.Context()
 node = PubNode(ctx)
 Hg.setupIO!(node, Hg.getIO(node))
+@test Hg.getname(node) == "PubNode"
+@test Hg.getname(Hg.getpublisher(node, 1)) == "test_pub"
+@test Hg.getname(Hg.getpublisher(node, 1).pub) == "test_pub"
+@test Hg.getname(Hg.getpublisher(node, "test_pub")) == "test_pub"
+@test Hg.getpublisher(node, "test_pub").msg isa TestMsg
+@test Hg.numpublishers(node) == 1
+@test Hg.numsubscribers(node) == 0
+
+Hg.printstatus(node)
 
 ## Initialize subscriber
 using Base.Threads
+Hg.reset_sub_count()
 subnode = SubNode()
 Hg.setupIO!(subnode, Hg.getIO(subnode))
-sub = Hg.getIO(subnode).subs[1]
+sub = Hg.getsubscriber(subnode, 1)
 @test isopen(sub.sub)
+@test sub === Hg.getsubscriber(subnode, "subscriber_1")
+@test isnothing(Hg.getsubscriber(subnode, "sub2"))
+@test Hg.numsubscribers(subnode) == 1
+@test Hg.numpublishers(subnode) == 0
+
+Hg.printstatus(subnode)
 
 ## Launch tasks
 task = @async Hg.launch(node)
@@ -105,13 +123,20 @@ subtask = Threads.@spawn Hg.launch(subnode)
 
 ##
 sleep(1)
-subnode.should_finish = true
-node.should_finish = true
+@test Hg.isrunning(Hg.getsubscriber(subnode, 1))
+Hg.stopnode(subnode)
+Hg.stopnode(node)
+@test !Hg.isrunning(Hg.getsubscriber(subnode, 1))
+@test !Hg.getflags(node).is_running[]
+@test !Hg.getflags(subnode).is_running[]
+
+Hg.printstatus(node)
+Hg.printstatus(subnode)
 
 sleep(0.5)
-pub = node.nodeio.pubs[1]
+pub = Hg.getpublisher(node, 1) 
 @test !isopen(pub.pub)
-sub = Hg.getIO(subnode).subs[1]
+sub = Hg.getsubscriber(subnode, 1) 
 @test !isopen(sub.sub)
 @test isempty(subnode.nodeio.sub_tasks)
 

--- a/test/node_tests.jl
+++ b/test/node_tests.jl
@@ -60,7 +60,6 @@ function Hg.setupIO!(node::SubNode, nodeio::Hg.NodeIO)
     port = 5555
     sub = Hg.ZmqSubscriber(ctx, addr, port)
     empty!(nodeio.subs)
-    empty!(nodeio.sub_tasks)
     Hg.add_subscriber!(nodeio, node.test_msg, sub)
 end
 
@@ -130,6 +129,8 @@ Hg.stopnode(node)
 @test !Hg.getflags(node).is_running[]
 @test !Hg.getflags(subnode).is_running[]
 
+@test !Hg.getflags(node).did_error[]
+@test !Hg.getflags(subnode).did_error[]
 Hg.printstatus(node)
 Hg.printstatus(subnode)
 
@@ -138,7 +139,9 @@ pub = Hg.getpublisher(node, 1)
 @test !isopen(pub.pub)
 sub = Hg.getsubscriber(subnode, 1) 
 @test !isopen(sub.sub)
-@test isempty(subnode.nodeio.sub_tasks)
+for submsg in subnode.nodeio.subs
+    @test isempty(submsg.task)
+end
 
 dx = node.test_msg.x - subnode.test_msg.x
 dy = node.test_msg.y - subnode.test_msg.y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Sockets
 using ZMQ
 using BenchmarkTools
 using Test
+using Logging
+Logging.disable_logging(Logging.Info)
 
 # Generate ProtoBuf julia files
 outdir = joinpath(@__DIR__, "jlout")

--- a/test/subscriber_tests.jl
+++ b/test/subscriber_tests.jl
@@ -193,4 +193,36 @@ end
         close(pub)
         close(sub)
     end
+
+end
+
+@testset "Published/Subscribed ZMQ Messages" begin
+    Hg.reset_sub_count()
+    ctx = ZMQ.Context()
+    addr = ip"127.0.0.1"
+    port = 5555
+
+    sub = Hg.ZmqSubscriber(ctx, addr, port, name = "TestSub")
+    pub = Hg.ZmqPublisher(ctx, addr, port, name = "TestPub")
+    msg = TestMsg(x = 10, y = 11, z = 12)
+    msg_out = TestMsg(x = 1, y = 2, z = 3)
+
+    submsg = Hg.SubscribedMessage(msg, sub)
+    pubmsg = Hg.PublishedMessage(msg_out, pub)
+
+    Hg.launchtask(submsg)
+    @test Hg.isrunning(submsg)
+    @test !Hg.getflags(submsg.sub).hasreceived
+    while (!Hg.getflags(submsg.sub).hasreceived)
+        Hg.publish(pubmsg)
+        sleep(0.001)
+    end
+    @test Hg.getflags(submsg.sub).hasreceived
+    @test isopen(sub)
+    @test isopen(pub)
+    @test Hg.isrunning(submsg)
+    Hg.forceclose(sub)
+    close(pub)
+    sleep(0.2)  # give a little bit of time to close the task
+    @test !Hg.isrunning(submsg)
 end


### PR DESCRIPTION
This PR adds some functionality back into the `Node` type. It adds a flags and options struct to `NodeIO` that is accessible to all nodes.
Also added some helpful flags to publishers and subscribers for checking status.
Added a `printstatus` method for printing a summary of a nodes, publisher, or subscriber
The task for a subscriber is now stored inside `SubscribedMessage` so that it can directly access the state of the subscription task