### PR TITLE
Nonblocking receive

### DIFF
--- a/src/node.jl
+++ b/src/node.jl
@@ -321,7 +321,7 @@ function closeall(node::Node)
     nodeio = getIO(node)
     # Close publishers and subscribers
     for submsg in nodeio.subs
-        forceclose(submsg.sub)
+        close(submsg.sub)
     end
     for pubmsg in nodeio.pubs
         close(pubmsg.pub)

--- a/src/node.jl
+++ b/src/node.jl
@@ -294,9 +294,10 @@ function launch(node::Node)
     catch err
         if err isa InterruptException
             @info "Closing node $(getname(node)). Got Keyboard Interrupt."
-            # Close everything
         else
             @warn "Closing node $(getname(node)). Closed with error."
+            Base.display_error(err)
+            Base.show_exception_stack(sterr, stacktrace())
             getflags(node).did_error[] = true
             rethrow(err)
         end

--- a/src/publishers/abstract_publisher.jl
+++ b/src/publishers/abstract_publisher.jl
@@ -36,4 +36,5 @@ function printstatus(pub::PublishedMessage; indent=0)
     println(prefix, "  Type: ", getcomtype(pub))
     println(prefix, "  Message Type: ", typeof(pub.msg))
     println(prefix, "  Has published? ", pub.pub.has_published[])
+    println(prefix, "  Is Open? ", isopen(pub.pub))
 end

--- a/src/publishers/zmq_publisher.jl
+++ b/src/publishers/zmq_publisher.jl
@@ -68,7 +68,7 @@ end
 
 getcomtype(::ZmqPublisher) = :zmq
 Base.isopen(pub::ZmqPublisher) = Base.isopen(pub.socket)
-function Base.close(pub::ZmqPublisher) 
+function Base.close(pub::ZmqPublisher)
     if isopen(pub.socket)
         @debug "Closing ZmqPublisher: $(getname(pub))"
         Base.close(pub.socket)

--- a/src/publishers/zmq_publisher.jl
+++ b/src/publishers/zmq_publisher.jl
@@ -69,7 +69,12 @@ end
 
 getcomtype(::ZmqPublisher) = :zmq
 Base.isopen(pub::ZmqPublisher) = Base.isopen(pub.socket)
-Base.close(pub::ZmqPublisher) = Base.close(pub.socket)
+function Base.close(pub::ZmqPublisher) 
+    if isopen(pub.socket)
+        @debug "Closing ZmqPublisher: $(getname(pub))"
+        Base.close(pub.socket)
+    end
+end
 
 function publish(pub::ZmqPublisher, proto_msg::ProtoBuf.ProtoType)
     if isopen(pub)

--- a/src/subscribers/abstract_subscriber.jl
+++ b/src/subscribers/abstract_subscriber.jl
@@ -34,6 +34,7 @@ function got_new!(sub::Subscriber)
 end
 
 function decode!(buf::ProtoBuf.ProtoType, bin_data)
+    # io = IOBuffer(bin_data)
     io = seek(convert(IOStream, bin_data), 0)
     ProtoBuf.readproto(io, buf)
 end

--- a/src/subscribers/abstract_subscriber.jl
+++ b/src/subscribers/abstract_subscriber.jl
@@ -33,13 +33,13 @@ function got_new!(sub::Subscriber)
     return flags.hasreceived
 end
 
-function decode!(buf::ProtoBuf.ProtoType, bin_data)
+function decode!(buf::ProtoBuf.ProtoType, bin_data::IOBuffer)
     # io = IOBuffer(bin_data)
-    io = seek(convert(IOStream, bin_data), 0)
-    ProtoBuf.readproto(io, buf)
+    # io = seek(convert(IOStream, bin_data), 0)
+    ProtoBuf.readproto(bin_data, buf)
 end
 
-function decode!(buf::AbstractVector{UInt8}, bin_data)
+function decode!(buf::AbstractVector{UInt8}, bin_data::IOBuffer)
     for i = 1:min(length(buf), length(bin_data))
         buf[i] = bin_data[i]
     end
@@ -94,6 +94,7 @@ function printstatus(sub::SubscribedMessage; indent=0)
     println(prefix, "  Is running? ", !isempty(sub.task) && !istaskdone(sub.task[end]))
     println(prefix, "  Is failed? ", !isempty(sub.task) && istaskfailed(sub.task[end]))
     println(prefix, "  Has received? ", getflags(sub.sub).hasreceived)
+    println(prefix, "  Is Open? ", isopen(sub.sub))
 end
 
 """

--- a/src/subscribers/zmq_subscriber.jl
+++ b/src/subscribers/zmq_subscriber.jl
@@ -65,7 +65,6 @@ struct ZmqSubscriber <: Subscriber
         )
 
         @info "Subscribing $name to: tcp://$ipaddr:$port"
-        should_finish = Threads.Atomic{Bool}(false)
         new(
             socket,
             port,
@@ -161,7 +160,7 @@ function subscribe(sub::ZmqSubscriber, buf, write_lock::ReentrantLock)
                 break
             end
         end
-        if sub.should_finish[]
+        if getflags(sub).should_finish[]
             @debug "[subscribe loop] Shutting Down subscriber $(getname(sub)) on: $(tcpstring(sub))."
         else
             @debug "[subscribe loop] Shutting Down subscriber $(getname(sub)) on: $(tcpstring(sub)). Socket was closed"

--- a/test/node_tests.jl
+++ b/test/node_tests.jl
@@ -121,7 +121,16 @@ subtask = Threads.@spawn Hg.launch(subnode)
 @test !istaskfailed(subtask)
 @test Hg.node_sockets_are_open(subnode)
 
+
+
 ##
+sub = Hg.getsubscriber(subnode, 1)
+sock = sub.sub.socket
+msg = ZMQ.Message()
+Hg.settimeout!(sub.sub, -1)
+@time ZMQ.msg_recv(sock, msg, 0)
+Hg.settimeout!(sub.sub, 2000)
+
 sleep(1)
 @test Hg.isrunning(Hg.getsubscriber(subnode, 1))
 Hg.stopnode(subnode)

--- a/test/node_tests.jl
+++ b/test/node_tests.jl
@@ -115,26 +115,18 @@ task = @async Hg.launch(node)
 @test !istaskfailed(task)
 @test Hg.node_sockets_are_open(node)
 
-subnode.should_finish = false 
+Hg.getflags(subnode).should_finish[] = false
 subtask = Threads.@spawn Hg.launch(subnode)
 @test !istaskdone(subtask)
 @test !istaskfailed(subtask)
 @test Hg.node_sockets_are_open(subnode)
 
-
-
 ##
-sub = Hg.getsubscriber(subnode, 1)
-sock = sub.sub.socket
-msg = ZMQ.Message()
-Hg.settimeout!(sub.sub, -1)
-@time ZMQ.msg_recv(sock, msg, 0)
-Hg.settimeout!(sub.sub, 2000)
-
 sleep(1)
 @test Hg.isrunning(Hg.getsubscriber(subnode, 1))
+Hg.stopnode(node)     # closing publisher first should be fine
 Hg.stopnode(subnode)
-Hg.stopnode(node)
+sleep(0.1)  # give some time for the tasks to finish
 @test !Hg.isrunning(Hg.getsubscriber(subnode, 1))
 @test !Hg.getflags(node).is_running[]
 @test !Hg.getflags(subnode).is_running[]

--- a/test/subscriber_tests.jl
+++ b/test/subscriber_tests.jl
@@ -6,19 +6,7 @@ using BenchmarkTools
 if !isdefined(@__MODULE__, :TestMsg)
     include("jlout/test_msg_pb.jl")
 end
-
-# Hg.reset_sub_count()
-# ctx = ZMQ.Context()
-# addr = ip"127.0.0.1"
-# port = 5555
-# sub = Hg.ZmqSubscriber(ctx, addr, port)
-# isopen(sub)
-# msg = TestMsg(x=0,y=0,z=0)
-# subtask = @async Hg.subscribe(sub, msg, ReentrantLock())
-# istaskdone(subtask)
-# istaskfailed(subtask)
-# Hg.forceclose(sub)
-# wait(subtask)
+ENV["JULIA_DEBUG"] = "Mercury"
 
 @testset "ZmqSubscriber" begin
     Hg.reset_sub_count()
@@ -62,48 +50,35 @@ end
         sub = Hg.ZmqSubscriber(ctx, addr, port)
         @test isopen(sub)
         msg = TestMsg(x = 10, y = 11, z = 12)
-        rtask = @task Hg.receive(sub, msg, ReentrantLock())
-        schedule(rtask)
-        @test !istaskdone(rtask)
-        @test !istaskfailed(rtask)
 
         pub = Hg.ZmqPublisher(ctx, addr, port)
         msg_out = TestMsg(x = 1, y = 2, z = 3)
         @test msg.x == 10
         @test msg.y == 11
         @test msg.z == 12
-        cnt = 0
-        for i = 1:1000
-            msg_out.x = i
+        sleep(0.2)  # needed to give time to set up publisher?
+
+        # publish and receive a message
+        @test !sub.flags.hasreceived
+        i = 1
+        for i = 1:100
             Hg.publish(pub, msg_out)
-            sleep(0.001)
-            if istaskdone(rtask)
-                cnt = i
+            if Hg.receive(sub, msg, ReentrantLock())
                 break
             end
         end
+        @test i < 100
         @test sub.flags.hasreceived
-        @test istaskdone(rtask)
-        @test msg.x == cnt   # The first many are "lost." It accepts the first one to be received.
+
+        # make sure the correct message was received
+        @test msg.x == 1 
         @test msg.y == 2
         @test msg.z == 3
         close(pub)
         close(sub)
     end
 
-    @testset "Receive performance" begin
-        ## Test receive performance
-        function pub_message(pub)
-            msg_out = TestMsg(x = 1, y = 2, z = 3)
-            global do_publish
-            i = 0
-            while (do_publish)
-                msg_out.x = i
-                Hg.publish(pub, msg_out)
-                i += 1
-                sleep(0.001)
-            end
-        end
+    @testset "Closing" begin
         sub = Hg.ZmqSubscriber(ctx, addr, port, name = "TestSub")
         pub = Hg.ZmqPublisher(ctx, addr, port, name = "TestPub")
         msg = TestMsg(x = 10, y = 11, z = 12)
@@ -119,39 +94,76 @@ end
         # sleep(1.0)
         @show sub.flags.hasreceived
         @test msg.x == msg_out.x
-        close_task = @async close(sub)
-        @test !istaskdone(close_task)  # waiting for receive to finish
-        @test isopen(sub)
-        @test isopen(pub)
-        @test sub.flags.isreceiving
-        @test islocked(sub.socket_lock)
 
-        sub.flags.hasreceived = false
-        Hg.publish_until_receive(pub, sub, msg_out)
-        @test sub.flags.hasreceived
-        sleep(0.1)
-        @test istaskdone(close_task)  # should be closed now that the receive finished
-        @test !isopen(sub)
-        sleep(0.1)  # sleep to wait for socket to close and the subscribe loop to exit
-        @test istaskdone(sub_task)  # the subscriber task should finish after the socket is closed
-        @test !istaskfailed(sub_task)  # The task shouldn't end with an error
-        close(pub)
-
-        sub = Hg.ZmqSubscriber(ctx, addr, port)
-        pub = Hg.ZmqPublisher(ctx, addr, port, name = "TestPub")
-        sub_task = @task Hg.subscribe(sub, msg, ReentrantLock())
-        schedule(sub_task)
-        Hg.publish_until_receive(pub, sub, msg_out)
-        !istaskdone(sub_task)
-        Hg.forceclose(sub)
-        sleep(0.1)  # wait for the task to finish
-        @test istaskdone(sub_task)  # the subscriber task should finish after the socket is closed
-        @test !istaskfailed(sub_task) # the EOFError should be caught
+        # Should be able to close at any time
+        close(sub)
+        sleep(0.1)  # wait a little bit to allow for the lock to be acquired
         @test !isopen(sub)
         @test isopen(pub)
         close(pub)
-        @test !isopen(pub)
     end
+
+    # @testset "Receive performance" begin
+    #     ## Test receive performance
+    #     function pub_message(pub)
+    #         msg_out = TestMsg(x = 1, y = 2, z = 3)
+    #         global do_publish
+    #         i = 0
+    #         while (do_publish)
+    #             msg_out.x = i
+    #             Hg.publish(pub, msg_out)
+    #             i += 1
+    #             sleep(0.001)
+    #         end
+    #     end
+    #     sub = Hg.ZmqSubscriber(ctx, addr, port, name = "TestSub")
+    #     pub = Hg.ZmqPublisher(ctx, addr, port, name = "TestPub")
+    #     msg = TestMsg(x = 10, y = 11, z = 12)
+    #     msg_out = TestMsg(x = 1, y = 2, z = 3)
+
+    #     # Close the task by waiting for a receive
+    #     sub_task = @task Hg.subscribe(sub, msg, ReentrantLock())
+    #     schedule(sub_task)
+    #     cnt = 0
+    #     timeout = 5.0 # seconds
+    #     @test Hg.publish_until_receive(pub, sub, msg_out, timeout)
+    #     @test !istaskdone(sub_task)
+    #     # sleep(1.0)
+    #     @show sub.flags.hasreceived
+    #     @test msg.x == msg_out.x
+    #     close_task = @async close(sub)
+    #     @test !istaskdone(close_task)  # waiting for receive to finish
+    #     @test isopen(sub)
+    #     @test isopen(pub)
+    #     @test sub.flags.isreceiving
+    #     @test islocked(sub.socket_lock)
+
+    #     sub.flags.hasreceived = false
+    #     Hg.publish_until_receive(pub, sub, msg_out)
+    #     @test sub.flags.hasreceived
+    #     sleep(0.1)
+    #     @test istaskdone(close_task)  # should be closed now that the receive finished
+    #     @test !isopen(sub)
+    #     sleep(0.1)  # sleep to wait for socket to close and the subscribe loop to exit
+    #     @test istaskdone(sub_task)  # the subscriber task should finish after the socket is closed
+    #     @test !istaskfailed(sub_task)  # The task shouldn't end with an error
+    #     close(pub)
+
+    #     sub = Hg.ZmqSubscriber(ctx, addr, port)
+    #     pub = Hg.ZmqPublisher(ctx, addr, port, name = "TestPub")
+    #     sub_task = @task Hg.subscribe(sub, msg, ReentrantLock())
+    #     schedule(sub_task)
+    #     Hg.publish_until_receive(pub, sub, msg_out)
+    #     !istaskdone(sub_task)
+    #     Hg.forceclose(sub)
+    #     sleep(0.1)  # wait for the task to finish
+    #     @test istaskdone(sub_task)  # the subscriber task should finish after the socket is closed
+    #     @test !istaskfailed(sub_task) # the EOFError should be caught
+    #     @test !isopen(sub)
+    #     @test isopen(pub)
+    #     close(pub)
+    #     @test !isopen(pub)
+    # end
 
     @testset "Testing Subscriber Conflate" begin
         ## Test receive performance
@@ -194,3 +206,46 @@ end
         close(sub)
     end
 end
+
+Hg.reset_sub_count()
+ctx = ZMQ.context()
+addr = ip"127.0.0.1"
+port = 5555
+
+function pub_message(pub)
+    msg_out = TestMsg(x = 1, y = 2, z = 3)
+    global do_publish
+    i = 0
+    while (do_publish[])
+        msg_out.x = i
+        Hg.publish(pub, msg_out)
+        i += 1
+        sleep(0.001)
+    end
+end
+
+sub = Hg.ZmqSubscriber(ctx, addr, port)
+msg = TestMsg(x = 0, y = 0, z = 0)
+
+pub = Hg.ZmqPublisher(ctx, addr, port, name = "TestPub")
+msg_out = TestMsg(x = 10, y = 11, z = 12)
+do_publish = Threads.Atomic{Bool}(true) 
+pub_task = @async pub_message(pub)
+istaskdone(pub_task)
+istaskfailed(pub_task)
+do_publish[] = false 
+isopen(pub)
+
+isopen(sub)
+lock = ReentrantLock()
+Hg.receive(sub, msg, lock) 
+msg.x
+b = @benchmark Hg.receive($sub, $msg, $lock) 
+@test maximum(b.gctimes) == 0
+sub_task = @async Hg.subscribe(sub, msg, ReentrantLock())
+istaskdone(sub_task)
+istaskfailed(sub_task)
+
+close(sub)
+close(pub)
+


### PR DESCRIPTION
This changes the behavior of the ZMQ receive so that it never blocks. It calls the low-level ZMQ `msg_recv` function with the `DONTWAIT` flag. I tried using the timeout functionality of the ZMQ receive function but got some odd behavior.

With this change, the nodes should be much easier to stop since the subscribers will never be stuck waiting for a message. You can close subscribers and publishers in any order.

I also optimized the ZMQ receive method to have zero memory allocations.